### PR TITLE
Avoid potential memory leak

### DIFF
--- a/tbr.h
+++ b/tbr.h
@@ -2957,7 +2957,7 @@ void leaf_reduction_hlpr(utree &T1, utree &T2, nodemapping &twins, map<int, int>
 				// add to nodemapping
 				twins.add(T1_new_terminal->get_label(), T2_new_terminal->get_label());
 
-				spi--;
+				if (spi != sibling_pairs.begin()) spi--;
 				sibling_pairs.erase(T1_a->get_label());
 				sibling_pairs.erase(T1_c->get_label());
 				break;


### PR DESCRIPTION
If `spi` references the first element of sibling_pairs, then the decrement will bring `spi` out of the range of `sibling_pairs`, which triggers a memory warning in ASAN.  (This is causing issues with using 'uspr' from within R.)

As `spi` is not used before the `break;` statement, it's not clear that it is necessary to decrement its value at all; I wonder whether the line can be deleted entirely?

My C++ knowledge is pretty thin, so it's quite possible that I'm overlooking something obvious here.